### PR TITLE
Adding params to execute_transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,32 +3,25 @@ py-arango
 
 [![Build
 Status](https://travis-ci.org/Joowani/py-arango.svg?branch=master)](https://travis-ci.org/Joowani/py-arango)
-[![Documentation
-Status](https://readthedocs.org/projects/py-arango/badge/?version=latest)](https://readthedocs.org/projects/py-arango/?badge=latest)
 
-Driver for ArangoDB REST API
+Python Driver for ArangoDB REST API
 
 Overview
 --------
 
-py-arango is a Python (2.7, 3.4) driver for ArangoDB
+py-arango is a Python 2.7 & 3.4 driver for ArangoDB
 (<https://www.arangodb.com/>)
-
-Documentation
--------------
-
-<http://py-arango.readthedocs.org/en/latest/>
 
 Installation
 ------------
 
--   Stable
+-   Stable (ArangoDB Version 2.5)
 
 ```bash
 sudo pip install py-arango
 ```
 
--   Latest
+-   Latest (ArangoDB Version 2.5)
 
 ```bash
 git clone https://github.com/Joowani/py-arango.git

--- a/arango/database.py
+++ b/arango/database.py
@@ -404,10 +404,9 @@ class Database(CursorFactory, BatchHandler):
     # Transactions #
     ################
 
-    # TODO deal with optional attribute "params"
     def execute_transaction(self, action, read_collections=None,
-                            write_collections=None, wait_for_sync=False,
-                            lock_timeout=None):
+                            write_collections=None, params=None,
+                            wait_for_sync=False, lock_timeout=None):
         """Execute the transaction and return the result.
 
         Setting the ``lock_timeout`` to 0 will make ArangoDB not time out
@@ -419,6 +418,8 @@ class Database(CursorFactory, BatchHandler):
         :type read_collections: str or list or None
         :param write_collections: the collections written to
         :type write_collections: str or list or None
+        :param params: Parameters for the function in action
+        :type params: list or dict or None
         :param wait_for_sync: wait for the transaction to sync to disk
         :type wait_for_sync: bool
         :param lock_timeout: timeout for waiting on collection locks
@@ -433,11 +434,13 @@ class Database(CursorFactory, BatchHandler):
             data["collections"]["read"] = read_collections
         if write_collections is not None:
             data["collections"]["write"] = write_collections
-        params = {
+        if params is not None:
+            data["params"] = params
+        http_params = {
             "waitForSync": wait_for_sync,
             "lockTimeout": lock_timeout,
         }
-        res = self._api.post(path=path, data=data, params=params)
+        res = self._api.post(path=path, data=data, params=http_params)
         if res.status_code != 200:
             raise TransactionExecuteError(res)
         return res.obj["result"]


### PR DESCRIPTION
Really appreciate the effort going into this driver -- just looking to add params to transactions. As far as I can tell this doesn't break compat with older versions, but I only tested on 2.5 (ran nosetests with new test case). 
